### PR TITLE
docs: synchronize READMEs, PRD, architecture, and contribution guides

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,19 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": {
+    "allowed_elements": [
+      "div",
+      "p",
+      "img",
+      "h1",
+      "a",
+      "b",
+      "i",
+      "span",
+      "br"
+    ]
+  },
+  "MD041": false
+}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,103 @@
 # Contributing to Fofoca Transcriptor
 
-Thank you for contributing to Fofoca Transcriptor! Please follow these streamlined steps to contribute:
+<p align="right">
+  <b>English 🇺🇸</b> | <a href="./CONTRIBUTING_pt.md">[Leia em Português 🇧🇷]</a>
+</p>
 
-1. **Fork & Branch:** Fork the repository and create your feature branch:
+Thank you for your interest in contributing to **Fofoca Transcriptor**! We welcome
+community contributions to enhance performance, expand local model capabilities,
+and refine user experience.
 
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+---
 
-2. **Environment Setup:** Ensure Python 3.12+ and `uv` are installed, then install dependencies:
+## 🔒 Core Guideline: Privacy & Offline First (Air-Gapped)
 
-   ```bash
-   uv sync --dev
-   ```
+Fofoca Transcriptor is fundamentally engineered as an **offline, private,
+air-gapped system**. To protect the integrity and founding mission of the project,
+all contributions must strictly respect these non-negotiable principles:
 
-3. **Linting & Code Quality:** Verify that your changes adhere to code style guidelines:
+* **100% Local Execution:** All speech recognition (Whisper) and speech
+  synthesis (Piper TTS) inference must execute entirely on local hardware (CPU/GPU).
+* **Zero Telemetry & Tracking:** The application must never emit outbound network
+  telemetry, usage metrics, crash reports, or analytics.
+* **No External Cloud APIs:** Pull requests introducing third-party SaaS APIs,
+  remote cloud fallbacks, remote authentication, or external data transmission
+  will **not** be accepted.
 
-   ```bash
-   uv run ruff check .
-   ```
+---
 
-4. **Testing:** Run the automated test suite to ensure all checks pass:
+## 🛠 Contribution Workflow
 
-   ```bash
-   uv run pytest -v
-   ```
+Please follow these streamlined steps to contribute:
 
-5. **Submit Pull Request:** Push your branch to GitHub and open a Pull Request targeting the `main` branch with a clear summary of your changes.
+### 1. Fork & Branch
+
+Fork the repository on GitHub and create a dedicated feature branch:
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+### 2. Environment Setup
+
+You can develop and test the application locally using either **Docker**
+(recommended for zero-setup environment parity) or **uv**:
+
+* **Option A: Using Docker (Fastest, isolated environment):**
+
+  ```bash
+  # Build and start the container
+  docker compose up --build
+
+  # Run test suite inside container
+  docker compose exec fofoca-app pytest -v
+  ```
+
+* **Option B: Using uv (Local environment):**
+
+  Ensure Python 3.12+, `uv`, and system packages for `ffmpeg` and
+  `espeak-ng` are installed, then sync dependencies:
+
+  ```bash
+  uv sync --dev
+  uv run python main.py
+  ```
+
+### 3. Linting, Formatting & Code Quality
+
+Verify that your changes adhere to code style guidelines and pass both static
+analysis and format checks:
+
+```bash
+# Verify linting rules (Ruff)
+uv run ruff check .
+
+# Verify code formatting (Ruff)
+uv run ruff format --check .
+
+# Automatically apply formatting fixes if needed
+uv run ruff format .
+```
+
+### 4. Automated Testing
+
+Run the full automated test suite to ensure all unit and integration checks pass:
+
+```bash
+uv run pytest -v
+```
+
+### 5. Submit Pull Request & Complete Template
+
+Push your branch to your GitHub fork and open a Pull Request targeting the
+`main` branch:
+
+* **Complete the PR Template:** Make sure to fill out **all** sections of our
+  [Pull Request Template](.github/pull_request_template.md), including:
+  * **Description of Changes:** Clear summary of what was changed and why.
+  * **Related Issue:** Link to the relevant issue (e.g., `Closes #12`).
+  * **Type of Change:** Select the appropriate category tags.
+  * **Contributor Checklist:** Verify all verification items (lint, format,
+    offline-first guarantee, test passing).
+  * **Screenshots / Validation:** Required for any modifications touching the
+    Gradio Web UI or CLI output.

--- a/CONTRIBUTING_pt.md
+++ b/CONTRIBUTING_pt.md
@@ -1,0 +1,104 @@
+# Guia de Contribuição — Fofoca Transcriptor
+
+<p align="right">
+  <a href="./CONTRIBUTING.md">[Read in English 🇺🇸]</a> | <b>Português 🇧🇷</b>
+</p>
+
+Obrigado pelo seu interesse em contribuir com o **Fofoca Transcriptor**! Aceitamos
+contribuições da comunidade para otimizar desempenho, expandir suporte a modelos
+neurais locais e aperfeiçoar a experiência de uso.
+
+---
+
+## 🔒 Diretriz Fundamental: Privacidade & Offline First (Air-Gapped)
+
+O Fofoca Transcriptor é concebido desde a sua raiz como um **sistema 100% offline,
+privado e air-gapped**. Para preservar a integridade e o propósito do projeto,
+todas as contribuições devem seguir rigorosamente os seguintes princípios inegociáveis:
+
+* **Execução 100% Local:** Todo o processamento de reconhecimento de fala
+  (Whisper) e síntese de voz (Piper TTS) deve ocorrer exclusivamente em hardware
+  local (CPU/GPU).
+* **Zero Telemetria e Rastreamento:** A aplicação não deve enviar telemetria
+  externa, métricas de uso, relatórios de crash ou analytics.
+* **Nenhuma API Externa em Nuvem:** Pull Requests que introduzam consumo de
+  APIs SaaS de terceiros, fallbacks remotos em nuvem, autenticação externa ou
+  transmissão remota de dados **não** serão aceitos.
+
+---
+
+## 🛠 Fluxo de Contribuição
+
+Siga os passos abaixo para contribuir de forma organizada:
+
+### 1. Fork & Criação de Branch
+
+Faça um fork do repositório no GitHub e crie uma branch específica para sua feature:
+
+```bash
+git checkout -b feature/nome-da-sua-feature
+```
+
+### 2. Configuração do Ambiente de Desenvolvimento
+
+Você pode desenvolver e testar a aplicação localmente utilizando **Docker**
+(recomendado para paridade imediata de ambiente) ou **uv**:
+
+* **Opção A: Utilizando Docker (Rápido, ambiente isolado):**
+
+  ```bash
+  # Construir a imagem e iniciar o container
+  docker compose up --build
+
+  # Executar a suíte de testes dentro do container
+  docker compose exec fofoca-app pytest -v
+  ```
+
+* **Opção B: Utilizando uv (Ambiente local):**
+
+  Certifique-se de que Python 3.12+, `uv` e os binários de sistema `ffmpeg` e
+  `espeak-ng` estão instalados, e então sincronize as dependências:
+
+  ```bash
+  uv sync --dev
+  uv run python main.py
+  ```
+
+### 3. Linting, Formatação & Qualidade de Código
+
+Verifique se as alterações respeitam os padrões de estilo do projeto executando
+o linter estático e a checagem de formatação:
+
+```bash
+# Validação de regras de linting (Ruff)
+uv run ruff check .
+
+# Validação estrita de formatação (Ruff)
+uv run ruff format --check .
+
+# Auto-formatação automática de código (se necessário)
+uv run ruff format .
+```
+
+### 4. Testes Automatizados
+
+Execute a suíte de testes automatizados com `pytest` para garantir a integridade da aplicação:
+
+```bash
+uv run pytest -v
+```
+
+### 5. Envio do Pull Request & Preenchimento do Template
+
+Envie sua branch para o seu fork no GitHub e abra um Pull Request apontando para
+a branch `main`:
+
+* **Preenchimento Completo do PR Template:** Certifique-se de preencher **todos**
+  os campos do nosso [Template de Pull Request](.github/pull_request_template.md):
+  * **Descrição das Mudanças:** Resumo claro do que foi implementado e justificativa.
+  * **Issue Relacionada:** Vínculo com a issue abordada (ex: `Closes #12`).
+  * **Tipo de Mudança:** Seleção das categorias correspondentes.
+  * **Checklist do Contribuidor:** Confirmação de que lint, formatação, testes e
+    a diretriz offline-first foram verificados.
+  * **Screenshots / Validação:** Obrigatório para qualquer alteração na interface
+    Gradio ou saída do terminal.

--- a/README.md
+++ b/README.md
@@ -137,8 +137,12 @@ fofoca/
 │   └── src/                 # Synthesis script (speaker.py)
 ├── tests/                   # Automated unit & integration tests
 │   └── test_basic.py        # Structural and module validation tests
+├── .dockerignore            # Docker build context exclusions
 ├── .env.example             # Configuration template
-├── CONTRIBUTING.md          # Contribution guidelines
+├── CONTRIBUTING.md          # Contribution guidelines (English)
+├── CONTRIBUTING_pt.md       # Contribution guidelines (Português)
+├── Dockerfile               # Production Docker container definition (uv + FFmpeg + espeak-ng)
+├── docker-compose.yml       # Docker Compose service orchestration & volume persistence
 ├── app.py                   # Gradio Web Application
 ├── main.py                  # CLI Entrypoint
 ├── pyproject.toml           # Package configuration & dependencies
@@ -148,7 +152,33 @@ fofoca/
 
 ---
 
-## 🚀 Local Installation & Setup
+## 🐳 Quick Start with Docker (Recommended)
+
+Run the entire suite with all system dependencies (Python 3.12, Astral `uv`, `FFmpeg`, and `espeak-ng`) pre-configured inside an isolated container:
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/SueliHora/fofoca.git
+cd fofoca
+
+# 2. Build and launch the container
+docker compose up --build
+```
+
+Access the Gradio Web UI in your browser:
+👉 **[http://localhost:7860](http://localhost:7860)**
+
+> [!TIP]
+>
+> * **Run in detached mode (background):** `docker compose up -d --build`
+> * **View container logs:** `docker compose logs -f`
+> * **Stop and remove container:** `docker compose down`
+> * **Run CLI batch transcription in container:** `docker compose exec fofoca-app python audio-to-text/src/transcriber.py`
+> * **Run CLI batch speech synthesis in container:** `docker compose exec fofoca-app python text-to-audio/src/speaker.py`
+
+---
+
+## 🚀 Local Installation & Setup (Without Docker)
 
 ### Prerequisites
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -135,8 +135,12 @@ fofoca/
 │   │   └── en_US-lessac-medium.onnx.json
 ├── tests/                   # Testes unitários e de integração
 │   └── test_basic.py        # Validações estruturais e de módulos
+├── .dockerignore            # Regras de exclusão para o build do Docker
 ├── .env.example             # Modelo de variáveis de ambiente
-├── CONTRIBUTING.md          # Guia de contribuição
+├── CONTRIBUTING.md          # Guia de contribuição (Inglês)
+├── CONTRIBUTING_pt.md       # Guia de contribuição (Português)
+├── Dockerfile               # Configuração do container Docker (uv + FFmpeg + espeak-ng)
+├── docker-compose.yml       # Orquestração do serviço e persistência de volumes
 ├── app.py                   # Interface Gráfica Gradio
 ├── main.py                  # Ponto de entrada CLI
 ├── pyproject.toml           # Configuração de pacote e dependências
@@ -146,7 +150,33 @@ fofoca/
 
 ---
 
-## 🚀 Como Executar o Projeto Localmente
+## 🐳 Início Rápido com Docker (Recomendado)
+
+Execute a aplicação completa com todas as dependências nativas (Python 3.12, Astral `uv`, `FFmpeg` e `espeak-ng`) isoladas e pré-configuradas em um único comando:
+
+```bash
+# 1. Clonar o repositório
+git clone https://github.com/SueliHora/fofoca.git
+cd fofoca
+
+# 2. Construir a imagem e iniciar o container
+docker compose up --build
+```
+
+Acesse a interface web no seu navegador:
+👉 **[http://localhost:7860](http://localhost:7860)**
+
+> [!TIP]
+>
+> * **Rodar em segundo plano (detached mode):** `docker compose up -d --build`
+> * **Visualizar logs do container:** `docker compose logs -f`
+> * **Parar e remover o container:** `docker compose down`
+> * **Executar transcrição em lote via CLI no container:** `docker compose exec fofoca-app python audio-to-text/src/transcriber.py`
+> * **Executar síntese de voz via CLI no container:** `docker compose exec fofoca-app python text-to-audio/src/speaker.py`
+
+---
+
+## 🚀 Como Executar o Projeto Localmente (Sem Docker)
 
 ### Pré-requisitos
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,12 @@ The codebase is organized into three primary architectural tiers:
 * **Inference Engine:** Powered by **Piper TTS** built on top of the **ONNX Runtime (Open Neural Network Exchange)**. It utilizes lightweight neural acoustic and vocoder models (VITS architecture) to generate synthetic waveform audio with high computational efficiency.
 * **Model Mapping & Resolution:** Implements deterministic lookup across local ONNX model checkpoints (`pt_BR-faber-medium.onnx` and `en_US-lessac-medium.onnx`) and their corresponding `.onnx.json` phoneme dictionaries.
 
+### 2.4 Infrastructure & Container Layer (`Dockerfile`, `docker-compose.yml`)
+* **Base Runtime:** Built upon Astral's official image `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`, providing Python 3.12, `uv` packaging, and minimal attack surface.
+* **System Runtime Dependencies:** Integrates OS-level `ffmpeg` (audio demuxing, decoding, and resampling) and `espeak-ng` (grapheme-to-phoneme phonemization for Piper TTS).
+* **High-Efficiency Caching:** Uses build cache mounts (`target=/root/.cache/uv`) with `uv sync --frozen --no-install-project` to separate external library installation from application code changes.
+* **Networking & Port Mapping:** Exposes port `7860:7860` for Gradio Web UI access, binding to `0.0.0.0` internally.
+
 ---
 
 ## 3. End-to-End Data Flow
@@ -140,3 +146,39 @@ fofoca/
 * **Zero Outbound Telemetry:** All inference computations occur strictly locally via PyTorch and ONNX Runtime. No customer data or audio segments are ever transmitted outside the host environment.
 * **No Cloud API Keys Required:** Unlike proprietary APIs, there is zero risk of credential leaks, rate limiting, or vendor lock-in.
 * **Clean Artifact Lifecycle:** All files written by the system remain strictly within the workspace folder hierarchy, ensuring easy auditing and compliance with enterprise data governance policies.
+
+---
+
+## 6. Infrastructure & Container Deployment Architecture
+
+The application provides a containerized deployment topology designed for zero-configuration portability and production readiness:
+
+```mermaid
+graph TD
+    HostUser([Host Browser / Terminal]) -->|Port 7860:7860| ContainerApp[Container: fofoca-app]
+    
+    subgraph "Docker Host Environment"
+        subgraph "Docker Container (fofoca-app)"
+            AppRuntime["Python 3.12 + Astral uv Environment"]
+            FFmpegBin["FFmpeg Binary (System)"]
+            EspeakBin["espeak-ng Binary (System)"]
+            GradioSrv["Gradio Web Server (0.0.0.0:7860)"]
+            InferenceUnits["Whisper (PyTorch) + Piper (ONNX)"]
+        end
+        
+        subgraph "Host Mounted Volumes (Bidirectional Persistence)"
+            HostAudioIn["./audio-to-text/input"] <-->|Mount| ContainerAudioIn["/app/audio-to-text/input"]
+            HostAudioOut["./audio-to-text/output"] <-->|Mount| ContainerAudioOut["/app/audio-to-text/output"]
+            HostTextIn["./text-to-audio/input"] <-->|Mount| ContainerTextIn["/app/text-to-audio/input"]
+            HostTextOut["./text-to-audio/output"] <-->|Mount| ContainerTextOut["/app/text-to-audio/output"]
+            HostModels["./text-to-audio/models"] <-->|Mount| ContainerModels["/app/text-to-audio/models"]
+            NamedCache["whisper-cache Volume"] <-->|Mount| ContainerCache["/root/.cache/whisper"]
+        end
+    end
+```
+
+### Key Architectural Characteristics:
+* **Isolation of Native Dependencies:** Eliminates host machine configuration discrepancies regarding FFmpeg or espeak-ng paths and binary versions across platforms.
+* **State & Artifact Segregation:** Input files, transcriptions (`.txt`), and synthesized audio (`.wav`) persist directly on the host file system via bind mounts, while downloaded Whisper neural weights persist in a dedicated Docker named volume (`whisper-cache`).
+* **Continuous Health Monitoring:** Built-in `HEALTHCHECK` queries the internal HTTP endpoint (`curl -f http://localhost:7860/`) every 30 seconds to guarantee service health within container orchestrators.
+

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -74,9 +74,10 @@ Modern audio/video transcription and speech synthesis workflows are predominantl
 * **NFR-2.1 (Model Caching):** Implement in-memory model caching to avoid expensive reload latencies across repeated user requests.
 * **NFR-2.2 (Hardware Acceleration):** Utilize PyTorch and ONNX Runtime backends capable of leveraging CUDA/ROCm when available, with seamless fallback to CPU vector execution.
 
-### 5.3 Modern Tooling & Packaging
+### 5.3 Modern Tooling, Packaging & Portability
 * **NFR-3.1 (Deterministic Dependency Resolution):** Fully integrated with `uv` for ultra-fast lockfile resolution, virtual environment provisioning, and reproducible builds.
 * **NFR-3.2 (Standard Compliance):** Comply with PEP 517, PEP 518, and PEP 621 specifications via `pyproject.toml`.
+* **NFR-3.3 (Containerization & Deployment Portability):** Provide production-grade containerization via optimized `Dockerfile` and `docker-compose.yml` leveraging official Astral `uv` base images. Must package native system runtimes (`ffmpeg` for Whisper ASR and `espeak-ng` for Piper TTS) to guarantee zero-configuration cross-platform reproducibility and one-command execution (`docker compose up --build`).
 
 ### 5.4 Maintainability & Quality Assurance
 * **NFR-4.1 (Unit Testing Suite):** Test coverage verifying directory structural integrity, module importability, and model mapping configurations via `pytest`.

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 Fofoca™ Transcriptor - Main Entry Point
 Author: Sueli da Hora Moreira
 """
+
 import os
 
 import gradio as gr


### PR DESCRIPTION
## 📌 Description of Changes
- Synchronizes `README.md` and `README_pt.md` with Docker quickstart instructions (`docker compose up --build`).
- Updates `docs/PRD.md` with containerization requirements and portability standards.
- Updates `docs/ARCHITECTURE.md` reflecting the Docker infrastructure layer.
- Enhances `CONTRIBUTING.md` and adds `CONTRIBUTING_pt.md` with strict offline/privacy guidelines, formatting checks (`ruff format --check .`), and PR template instructions.
- Adds `.markdownlint.json` to standardize markdown linting rules without breaking visual GitHub components.

## 🔗 Related Issue
N/A (Documentation & Developer Experience sync)

## 🛠️ Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to break)
- [x] 📝 Documentation update (fixing or adding docs)
- [ ] ⚡ Performance improvement / Refactoring
- [ ] 🧪 Tests / CI configuration

## ✅ Contributor Checklist
Before submitting this pull request, please ensure the following:

- [x] My branch is up to date with `main`.
- [x] All code changes adhere to the repository's architecture and coding standards.
- [x] Linter checks pass locally via `uv run ruff check .`.
- [x] Code formatting passes locally via `uv run ruff format --check .`.
- [x] All unit and integration tests pass via `uv run pytest`.
- [x] The local offline/air-gapped nature of the project is strictly preserved (no external cloud APIs or telemetry added).
- [x] Corresponding documentation (such as `docs/ARCHITECTURE.md` or READMEs) was updated if applicable.